### PR TITLE
changes images() to files() in filter recipe

### DIFF
--- a/content/1_docs/2_cookbook/2_content/0_filtering/recipe.txt
+++ b/content/1_docs/2_cookbook/2_content/0_filtering/recipe.txt
@@ -90,7 +90,7 @@ $images = page('blog')
 
 // get all file types exept images
 $files = page('blog')
-  ->images()
+  ->files()
   ->filterBy('type', '!=', 'image');
 ```
 
@@ -186,7 +186,7 @@ $collection = page('events')
 ```php
 // fetch all files that are neither videos nor images
 $files = $page
-  ->images()
+  ->files()
   ->filterBy('type', '!=', 'video')
   ->filterBy('type', '!=', 'image');
 ```


### PR DESCRIPTION
I thing there are two `images()` method in this recipe where `files()` should be used instead.